### PR TITLE
Caching types update

### DIFF
--- a/Editor/Implementation/Logic/TryCacheTypesLogic.cs
+++ b/Editor/Implementation/Logic/TryCacheTypesLogic.cs
@@ -3,7 +3,6 @@ using Juce.ImplementationSelector.Data;
 using System;
 using System.Linq;
 
-
 namespace Juce.ImplementationSelector.Logic
 {
     public static class TryCacheTypesLogic

--- a/Editor/Implementation/Logic/TryCacheTypesLogic.cs
+++ b/Editor/Implementation/Logic/TryCacheTypesLogic.cs
@@ -1,6 +1,8 @@
-﻿using Juce.ImplementationSelector.Data;
+﻿using UnityEditor;
+using Juce.ImplementationSelector.Data;
 using System;
 using System.Linq;
+
 
 namespace Juce.ImplementationSelector.Logic
 {

--- a/Editor/Implementation/Logic/TryCacheTypesLogic.cs
+++ b/Editor/Implementation/Logic/TryCacheTypesLogic.cs
@@ -18,16 +18,13 @@ namespace Juce.ImplementationSelector.Logic
 
             Type baseType = typeAttribute.FieldType;
 
-            editorData.Types = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
-                .Where(x => 
-                    baseType != x &&
-                    baseType.IsAssignableFrom(x) && 
-                    !x.IsAbstract && 
-                    !x.IsSubclassOf(typeof(UnityEngine.Object)) && 
-                    x.GetConstructor(Type.EmptyTypes) != null
-                    )
-                .ToArray();
+            editorData.Types = TypeCache.GetTypesDerivedFrom(baseType).Where(x => 
+	            baseType != x &&
+	            baseType.IsAssignableFrom(x) &&
+	            !x.IsAbstract &&
+	            !x.IsSubclassOf(typeof(UnityEngine.Object)) &&
+	            (x.GetConstructor(Type.EmptyTypes) != null || x.IsValueType)
+            ).ToArray();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ We are always aiming to improve this tool. You can always leave suggestions on t
 ## Contributors
 
 - Guillem SC - [@Guillemsc](https://github.com/Guillemsc)
+- Balázs K - [@BallerJColt](https://github.com/BallerJColt)


### PR DESCRIPTION
Caching type names now uses Unity's built-in TypeCache, as it is faster.
Filtering now checks if the type has an empty constructor type OR if it's a value type to allow structs to be instantiated.