### PR TITLE
Update SerializedPropertyExtensions.cs

### DIFF
--- a/Editor/Extensions/SerializedPropertyExtensions.cs
+++ b/Editor/Extensions/SerializedPropertyExtensions.cs
@@ -21,6 +21,7 @@ namespace Juce.ImplementationSelector.Extensions
             {
                 height += EditorGUI.GetPropertyHeight(serializedProperty);
                 serializedProperty.NextVisible(false);
+                height += EditorGUIUtility.standardVerticalSpacing;
             }
 
             return height;


### PR DESCRIPTION
Having a more than 6 serialized properties caused inspector to draw them on top of the next element. ```StandardVerticalSpacing``` was added to the total ```VisibleChildHeight```